### PR TITLE
Fix typo in About Card

### DIFF
--- a/src/components/About/AboutCard.js
+++ b/src/components/About/AboutCard.js
@@ -20,7 +20,7 @@ function AboutCard() {
               <ImPointRight /> Playing Games
             </li>
             <li className="about-activity">
-              <ImPointRight /> Pratice Sports
+              <ImPointRight /> Practice Sports
             </li>
             <li className="about-activity">
               <ImPointRight /> Travelling


### PR DESCRIPTION
Found a typo on https://portfolionouffel.vercel.app/about -> "Practice" instead of "Pratice" 😉 